### PR TITLE
Bill page view Nuxt UI

### DIFF
--- a/pages/bills/[id].vue
+++ b/pages/bills/[id].vue
@@ -1,0 +1,128 @@
+<template>
+    <div>
+        <PageHeader
+            :pageTitle="displayBill.title"
+            :pageSubtitle="billTypeLabel"
+            :pageDate="displayBill.introducedDate"
+            :colour="displayBill.headerColour"
+        />
+        <NuxtPage :bill="displayBill" :status="status" :error="error" :refresh="refresh" />
+    </div>
+</template>
+
+<script setup lang="ts">
+const config = useRuntimeConfig()
+const apiBase = config.public.apiBase
+const route = useRoute()
+
+const billKey = computed(() => `bill-${route.params.id}`)
+const { data: bill, status, error, refresh } = await useAsyncData(
+    billKey,
+    () => $fetch(`${apiBase}bills/${route.params.id}/`),
+    { lazy: true }
+)
+
+const exampleBill = {
+    title: 'Anzac Day Amendment Bill',
+    type: 'government',
+    introducedDate: '2025-04-03',
+    headerColour: '#58787f',
+    summary:
+        'This bill amends the Anzac Day Act 1966 to cover other conflicts and persons who have served New Zealand in time of war or in warlike conflicts in the past and in the future that are not currently covered by the Act.',
+    status: 'in_progress',
+    statusSummary:
+        'This Bill passed its first reading on 3 April 2025. The Select Committee report was due back on 2 October 2025 and the Bill is awaiting its second reading. Public submissions were due on 21 May 2025.',
+    resources: {
+        billText: {
+            label: 'Anzac Day Amendment Bill (legislation.govt.nz)',
+            url: 'https://www.legislation.govt.nz/bill/government/2025/0010/latest/LMS000000.html'
+        },
+        parliament: {
+            label: 'View on Parliament website',
+            url: 'https://www.parliament.nz/en/pb/bills-and-laws/bills-proposed-laws/document/00DBHOH_BILL00000000000000/anzac-day-amendment-bill'
+        },
+        json: {
+            label: 'JSON',
+            url: 'https://api.wheretheystand.nz/v2/bills/example/'
+        }
+    },
+    votingMethod: {
+        label: 'Party voting',
+        description:
+            'Parties decided whether or not to support this bill and cast votes on behalf of all their MPs.'
+    },
+    proceduralNotes: [
+        {
+            title: 'Urgency used',
+            description:
+                'This bill was progressed through one or more stages using urgency. Urgency allows the Government to fast-track the legislative process by extending the sitting hours of the House of Representatives and skipping the select committee stage of a bill, and allows bills to pass through more than one stage per sitting day.',
+            link: {
+                label: 'Learn more about urgency',
+                url: 'https://www.parliament.nz/en/visit-and-learn/how-parliament-works/laws-and-bills/what-happens-to-a-bill/'
+            }
+        },
+        {
+            title: 'Extended sittings used',
+            description:
+                'This bill was progressed during one or more extended sittings of the House of Representatives. This enables MPs to meet for longer than normal to consider legislation. It allows bills to pass through more than one stage per sitting day.',
+            link: {
+                label: 'Learn more about extended sittings',
+                url: 'https://www.parliament.nz/en/visit-and-learn/how-parliament-works/parliamentary-business/house-sitting-patterns/'
+            }
+        }
+    ],
+    member: {
+        name: 'Paul Goldsmith',
+        role: 'National List MP',
+        avatar: '/images/generic-profile-picture.png',
+        link: '/people/paul-goldsmith'
+    },
+    votes: [
+        {
+            stage: '1st reading',
+            status: 'passed',
+            date: '2025-04-03',
+            totals: {
+                ayes: 68,
+                noes: 55,
+                abstentions: 0,
+                absent: 0
+            }
+        },
+        {
+            stage: '2nd reading',
+            status: 'not_recorded',
+            details: 'This vote has not yet occurred, or is not yet recorded on WhereTheyStand.'
+        },
+        {
+            stage: '3rd reading',
+            status: 'not_recorded',
+            details: 'This vote has not yet occurred, or is not yet recorded on WhereTheyStand.'
+        }
+    ],
+    votesNote:
+        'Only reading votes are shown here; these votes determine whether the Bill progresses through Parliament. Other votes, such as votes on whether to amend parts of the Bill, can be seen in Hansard.',
+    lastSynced:
+        'Bill details last synced with the Parliament website 17 days ago. (31 December 2025 at 01:49 GMT+13:00)'
+}
+
+const displayBill = computed(() => {
+    const data = bill.value && typeof bill.value === 'object' ? (bill.value as Record<string, any>) : {}
+    return {
+        ...exampleBill,
+        title: data.name ?? data.title ?? exampleBill.title,
+        type: data.type ?? exampleBill.type,
+        introducedDate: data.introduced_date ?? data.introducedDate ?? exampleBill.introducedDate,
+        status: data.status ?? exampleBill.status,
+        statusSummary: data.status_summary ?? exampleBill.statusSummary,
+        summary: data.summary ?? data.description ?? exampleBill.summary,
+        member: data.member ?? exampleBill.member
+    }
+})
+
+const billTypeLabel = computed(() => {
+    const types = config.public.valueKeys?.billTypes ?? {}
+    const typeKey = displayBill.value.type
+    return (types as Record<string, { description?: string }>)[typeKey]?.description ?? String(typeKey)
+})
+</script>

--- a/pages/bills/[id]/index.vue
+++ b/pages/bills/[id]/index.vue
@@ -1,0 +1,222 @@
+<template>
+    <UContainer class="my-8 space-y-8">
+        <UCard v-if="status === 'error'" variant="subtle" class="w-full">
+            <UEmpty title="Bill data unavailable"
+                description="We could not load this bill yet, so example data is shown below.">
+                <template #actions>
+                    <UButton variant="subtle" color="neutral" @click="refresh?.()" class="mt-4"
+                        icon="i-lucide-refresh-cw" trailing>
+                        Retry
+                    </UButton>
+                </template>
+            </UEmpty>
+            <p v-if="error" class="text-muted text-xs text-center mt-4">
+                {{ error.statusCode }}: {{ error }}
+            </p>
+        </UCard>
+
+        <div class="grid gap-6 lg:grid-cols-3">
+            <UCard class="lg:col-span-2">
+                <template #header>
+                    <div class="flex items-center justify-between gap-4">
+                        <h2 class="text-lg font-semibold">About this bill</h2>
+                    </div>
+                </template>
+
+                <p class="text-sm text-muted leading-relaxed">
+                    {{ bill.summary }}
+                </p>
+
+                <div class="mt-5 space-y-5">
+                    <div>
+                        <h3 class="text-sm font-semibold">Read the bill</h3>
+                        <div class="mt-2 flex flex-col gap-2 text-sm">
+                            <ULink v-if="resources.billText" :href="resources.billText.url" target="_blank"
+                                class="inline-flex items-center gap-2">
+                                <UIcon name="i-lucide-file-text" class="text-muted" />
+                                <span>{{ resources.billText.label }}</span>
+                                <UIcon name="i-lucide-external-link" class="text-muted" />
+                            </ULink>
+                        </div>
+                    </div>
+
+                    <div v-if="votingMethod">
+                        <h3 class="text-sm font-semibold">Voting method</h3>
+                        <p class="mt-1 text-sm text-muted">
+                            <span class="font-semibold text-default">{{ votingMethod.label }}:</span>
+                            {{ votingMethod.description }}
+                        </p>
+                    </div>
+
+                    <div v-if="proceduralNotes.length">
+                        <h3 class="text-sm font-semibold">Procedural notes</h3>
+                        <ul class="mt-2 space-y-2 text-sm text-muted">
+                            <li v-for="note in proceduralNotes" :key="note.title">
+                                <span class="font-semibold text-default">{{ note.title }}:</span>
+                                {{ note.description }}
+                                <ULink v-if="note.link" :href="note.link.url" target="_blank"
+                                    class="inline-flex items-center gap-1">
+                                    {{ note.link.label }}
+                                    <UIcon name="i-lucide-external-link" class="text-muted" />
+                                </ULink>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+
+                <template #footer>
+                    <div class="flex flex-wrap items-center justify-between gap-2 text-sm">
+                        <ULink v-if="resources.parliament" :href="resources.parliament.url" target="_blank"
+                            class="inline-flex items-center gap-2">
+                            {{ resources.parliament.label }}
+                            <UIcon name="i-lucide-external-link" class="text-muted" />
+                        </ULink>
+                        <ULink v-if="resources.json" :href="resources.json.url" target="_blank"
+                            class="inline-flex items-center gap-2 text-muted">
+                            <UIcon name="i-lucide-code" />
+                            {{ resources.json.label }}
+                        </ULink>
+                    </div>
+                </template>
+            </UCard>
+
+            <UCard>
+                <template #header>
+                    <div class="flex items-center justify-between gap-4">
+                        <h2 class="text-lg font-semibold">Progress</h2>
+                        <UBadge :color="statusMeta.colour" variant="soft">
+                            {{ statusMeta.description }}
+                        </UBadge>
+                    </div>
+                </template>
+                <div class="space-y-3">
+                    <p class="text-2xl font-semibold">{{ statusMeta.description }}</p>
+                    <p class="text-sm text-muted">{{ bill.statusSummary }}</p>
+                </div>
+            </UCard>
+        </div>
+
+        <div>
+            <h2 class="text-lg font-semibold mb-3">Member responsible</h2>
+            <UCard>
+                <div class="flex flex-wrap items-center gap-4">
+                    <UAvatar :src="member.avatar" :alt="member.name" size="lg" />
+                    <div class="flex-1 min-w-[180px]">
+                        <p class="font-semibold">{{ member.name }}</p>
+                        <p class="text-sm text-muted">{{ member.role }}</p>
+                    </div>
+                    <UButton v-if="member.link" variant="subtle" color="neutral" :to="member.link"
+                        icon="i-lucide-arrow-right" trailing>
+                        View profile
+                    </UButton>
+                </div>
+            </UCard>
+        </div>
+
+        <div>
+            <div class="flex flex-wrap items-center justify-between gap-3 mb-3">
+                <h2 class="text-lg font-semibold">Votes</h2>
+                <UBadge variant="soft" color="neutral">{{ votes.length }} readings</UBadge>
+            </div>
+            <div class="grid gap-4 lg:grid-cols-3">
+                <UCard v-for="vote in votes" :key="vote.stage">
+                    <div class="flex items-center justify-between gap-4">
+                        <p class="text-xs font-semibold uppercase tracking-wide text-muted">{{ vote.stage }}</p>
+                        <UBadge :color="voteStatusMeta(vote).color" variant="soft">
+                            {{ voteStatusMeta(vote).label }}
+                        </UBadge>
+                    </div>
+                    <p class="mt-2 text-sm text-muted" v-if="vote.date">{{ formatDate(vote.date) }}</p>
+                    <p class="mt-2 text-sm text-muted" v-else>Not yet scheduled</p>
+                    <p v-if="vote.details" class="mt-4 text-sm text-muted">{{ vote.details }}</p>
+                    <div v-else-if="vote.totals" class="mt-4 grid grid-cols-4 gap-2 text-center text-xs">
+                        <div v-for="total in totalsForVote(vote)" :key="total.label"
+                            class="flex flex-col items-center gap-1">
+                            <span class="text-lg font-semibold text-default">{{ total.value }}</span>
+                            <span class="inline-flex items-center gap-1 text-[10px] uppercase text-muted">
+                                <span :class="['h-2 w-2 rounded-full', total.color]" />
+                                {{ total.label }}
+                            </span>
+                        </div>
+                    </div>
+                    <p v-else class="mt-4 text-sm text-muted">Totals not available yet.</p>
+                </UCard>
+            </div>
+            <p v-if="bill.votesNote" class="mt-4 text-xs text-muted">{{ bill.votesNote }}</p>
+            <p v-if="bill.lastSynced" class="mt-2 text-xs text-muted">{{ bill.lastSynced }}</p>
+        </div>
+    </UContainer>
+</template>
+
+<script setup lang="ts">
+import { format } from 'date-fns'
+
+const props = defineProps({
+    bill: {
+        type: Object,
+        required: true
+    },
+    status: {
+        type: String,
+        default: 'pending'
+    },
+    error: {
+        type: Object,
+        default: null
+    },
+    refresh: {
+        type: Function,
+        default: null
+    }
+})
+
+const config = useRuntimeConfig()
+
+const { bill, status, error, refresh } = toRefs(props)
+
+const resources = computed(() => bill.value?.resources ?? {})
+const member = computed(() => bill.value?.member ?? {})
+const votingMethod = computed(() => bill.value?.votingMethod ?? null)
+const proceduralNotes = computed(() =>
+    Array.isArray(bill.value?.proceduralNotes) ? bill.value.proceduralNotes : []
+)
+const votes = computed(() => (Array.isArray(bill.value?.votes) ? bill.value.votes : []))
+
+const statusMeta = computed(() => {
+    const statuses = config.public.valueKeys?.billStatuses ?? {}
+    const key = bill.value?.status ?? 'unknown'
+    return (statuses as Record<string, { description?: string; colour?: string }>)[key] ?? {
+        description: 'Unknown',
+        colour: 'neutral'
+    }
+})
+
+const voteStatusLookup: Record<string, { label: string; color: string }> = {
+    passed: { label: 'Passed', color: 'success' },
+    defeated: { label: 'Defeated', color: 'error' },
+    not_recorded: { label: 'Not recorded', color: 'neutral' },
+    scheduled: { label: 'Scheduled', color: 'primary' }
+}
+
+const voteStatusMeta = (vote: Record<string, any>) => {
+    return voteStatusLookup[vote.status] ?? { label: vote.status ?? 'Unknown', color: 'neutral' }
+}
+
+const totalsForVote = (vote: Record<string, any>) => {
+    return [
+        { label: 'Ayes', value: vote.totals?.ayes ?? 0, color: 'bg-emerald-500' },
+        { label: 'Noes', value: vote.totals?.noes ?? 0, color: 'bg-rose-500' },
+        { label: 'Abst.', value: vote.totals?.abstentions ?? 0, color: 'bg-amber-500' },
+        { label: 'Abse.', value: vote.totals?.absent ?? 0, color: 'bg-sky-500' }
+    ]
+}
+
+const formatDate = (date?: string) => {
+    if (!date) return ''
+    const parsedDate = date.length === 10 && /^\d{4}-\d{2}-\d{2}$/.test(date)
+        ? new Date(date + 'T00:00:00')
+        : new Date(date)
+    if (Number.isNaN(parsedDate.getTime())) return date
+    return format(parsedDate, 'd MMMM yyyy')
+}
+</script>


### PR DESCRIPTION
Implement the bill detail page using Nuxt UI, including a data fetching wrapper and example data, as part of the site redevelopment.

---
<a href="https://cursor.com/background-agent?bcId=bc-fd241586-6471-48f2-b438-a60fa47ea14e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fd241586-6471-48f2-b438-a60fa47ea14e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements the bill detail experience with data fetching and a Nuxt UI layout.
> 
> - Adds `pages/bills/[id].vue` to fetch a bill from `apiBase` via `useAsyncData`, merge with example fallback data, and compute `billTypeLabel`
> - Adds `pages/bills/[id]/index.vue` to render bill details: summary, resources, voting method, procedural notes, progress/status badge, member card, and votes (status, totals, formatted dates)
> - Handles error state with retry and reads `valueKeys` for bill types/statuses
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17cf243d8d1b3df50fc7e055a159a4fbcb550511. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->